### PR TITLE
Transfuse passes the TCK

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ The following dependency injection systems have passed the [TCK][release]:
   * [OpenWebBeans](http://openwebbeans.apache.org/1.0.0-SNAPSHOT/jsr330.html)
   * [Spring Framework 3.0](http://www.springsource.com/download/community)
   * [Weld 1.0.0](http://www.seamframework.org/Weld)
+  * [Transfuse](http://androidtransfuse.org/)
 
 ## License
 


### PR DESCRIPTION
On the Transfuse project (http://androidtransfuse.org/) We're huge fans of the JSR330 and were happy to satisfy the TCK tests that shipped with the standard.

Here's the proof:
https://github.com/johncarl81/transfuse/blob/master/transfuse/src/test/java/org/androidtransfuse/JSR330TckTest.java

This PR is to include Transfuse as an implementation of JSR330 and one that passes the TCK tests.
